### PR TITLE
add megapixels package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,11 +32,13 @@ case "$device" in
     arch="arm64"
     family="sunxi"
     SERVICES="eg25-manager"
+    PACKAGES="megapixels"
     ;;
   "pinephonepro"|"pinetab2"|"rockchip" )
     arch="arm64"
     family="rockchip"
     SERVICES="eg25-manager"
+    PACKAGES="megapixels megapixels-config-pinephonepro"
     ;;
   "pocof1"|"oneplus6"|"oneplus6t"|"sdm845" )
     arch="arm64"


### PR DESCRIPTION
## Summary by Sourcery

Integrate the megapixels package into the build script for supported ARM64 devices

New Features:
- Add megapixels package to builds for Allwinner sunxi devices
- Add megapixels and megapixels-config-pinephonepro packages for Rockchip-based PinePhone Pro and PineTab2 devices